### PR TITLE
Please merge fix for PG 9.5 and 9.6 compatibility

### DIFF
--- a/ctidscan.c
+++ b/ctidscan.c
@@ -117,13 +117,17 @@ static void ExplainCtidScan(CustomScanState *node, List *ancestors,
 static CustomPathMethods	ctidscan_path_methods = {
 	"ctidscan",				/* CustomName */
 	PlanCtidScanPath,		/* PlanCustomPath */
+#if PG_VERSION_NUM < 90600
 	NULL,					/* TextOutCustomPath */
+#endif
 };
 
 static CustomScanMethods	ctidscan_scan_methods = {
 	"ctidscan",				/* CustomName */
 	CreateCtidScanState,	/* CreateCustomScanState */
+#if PG_VERSION_NUM < 90600
 	NULL,					/* TextOutCustomScan */
+#endif
 };
 
 static CustomExecMethods	ctidscan_exec_methods = {
@@ -134,6 +138,11 @@ static CustomExecMethods	ctidscan_exec_methods = {
 	ReScanCtidScan,			/* ReScanCustomScan */
 	NULL,					/* MarkPosCustomScan */
 	NULL,					/* RestrPosCustomScan */
+#if PG_VERSION_NUM >= 90600
+	NULL,					/* EstimateDSMCustomScan */
+	NULL,					/* InitializeDSMCustomScan */
+	NULL,					/* InitializeWorkerCustomScan */
+#endif
 	ExplainCtidScan,		/* ExplainCustomScan */
 };
 
@@ -447,6 +456,9 @@ SetCtidScanPath(PlannerInfo *root, RelOptInfo *baserel,
 		cpath->path.type = T_CustomPath;
 		cpath->path.pathtype = T_CustomScan;
 		cpath->path.parent = baserel;
+#if PG_VERSION_NUM >= 90600
+		cpath->path.pathtarget = baserel->reltarget;
+#endif
 		cpath->path.param_info
 			= get_baserel_parampathinfo(root, baserel, required_outer);
 		cpath->flags = CUSTOMPATH_SUPPORT_BACKWARD_SCAN;

--- a/ctidscan.c
+++ b/ctidscan.c
@@ -99,7 +99,8 @@ static Plan *PlanCtidScanPath(PlannerInfo *root,
 							  RelOptInfo *rel,
 							  CustomPath *best_path,
 							  List *tlist,
-							  List *clauses);
+							  List *clauses,
+							  List *custom_plans);
 
 /* CustomScanMethods */
 static Node *CreateCtidScanState(CustomScan *custom_plan);
@@ -468,7 +469,8 @@ PlanCtidScanPath(PlannerInfo *root,
 				 RelOptInfo *rel,
 				 CustomPath *best_path,
 				 List *tlist,
-				 List *clauses)
+				 List *clauses,
+				 List *custom_plans)
 {
 	List		   *ctid_quals = best_path->custom_private;
 	CustomScan	   *cscan = makeNode(CustomScan);
@@ -774,10 +776,9 @@ ExplainCtidScan(CustomScanState *node, List *ancestors, ExplainState *es)
 		qual = (Node *) make_ands_explicit(cscan->custom_exprs);
 
 		/* Set up deparsing context */
-		context = deparse_context_for_planstate((Node *)&node->ss.ps,
-												ancestors,
-												es->rtable,
-												es->rtable_names);
+		context = set_deparse_context_planstate(es->deparse_cxt,
+												(Node *) &node->ss.ps,
+                                                ancestors);
 
 		/* Deparse the expression */
 		exprstr = deparse_expression(qual, context, useprefix, false);


### PR DESCRIPTION
I made a patch to work ctidscan with PG 9.5 and 9.6.
I have tested my patch under 9.5.4 and 9.6.0.
Please merge my pull request.
